### PR TITLE
chore: remove redis

### DIFF
--- a/integration/rest_service/providers/clients.py
+++ b/integration/rest_service/providers/clients.py
@@ -1,23 +1,15 @@
 from __future__ import unicode_literals
 
-from os import getenv
 from typing import Dict, Union
 
-import redis_lock
 import requests
 from flask import Flask
 from flask_caching import Cache
-from redis import StrictRedis
 from requests import HTTPError
 from six.moves.urllib.parse import urljoin
 
 from integration.rest_service.providers import exceptions
 
-conn = StrictRedis(
-    host=getenv("REDIS_CACHE_HOSTNAME"),
-    port=int(getenv("REDIS_CACHE_PORT")),
-    db=int(getenv("REDIS_CACHE_DATABASE")),
-)
 config = {"DEBUG": True, "CACHE_TYPE": "simple", "CACHE_DEFAULT_TIMEOUT": 300}
 app = Flask(__name__)
 app.config.from_mapping(config)
@@ -40,15 +32,16 @@ class GenericAPIClient(object):
         self._set_headers(force_refresh=True)
 
     def _set_headers(self, force_refresh=False):
-        with redis_lock.Lock(conn, f"bgc-{self.base_url}", expire=60):
-            if force_refresh:
-                headers = self.get_headers()
-            else:
-                headers = cache.get(f"bgc-{self.base_url}")
+        if force_refresh:
+            headers = self.get_headers()
+        else:
+            headers = cache.get(f"bgc-{self.base_url}")
 
-                if not headers:
-                    headers = self.get_headers()
-                    cache.set(f"bgc-{self.base_url}", headers)
+            if not headers:
+                headers = self.get_headers()
+                cache.set(f"bgc-{self.base_url}", headers)
+
+        self.client.headers.update(headers)
 
     def get_headers(self) -> Dict[str, str]:
         return dict()

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,9 +22,7 @@ py==1.9.0
 Pygments==2.7.1
 pyparsing==2.4.7
 pytest==6.1.1
-python-redis-lock==3.6.0
 readme-renderer==27.0
-redis==3.5.3
 requests==2.21.0
 requests-toolbelt==0.9.1
 rfc3986==1.4.0

--- a/setup.py
+++ b/setup.py
@@ -10,9 +10,7 @@ setup(
     long_description=open("README.md").read(),
     install_requires=[
         "Flask==1.1.2",
-        "redis==3.5.3",
         "pytest==6.1.1",
-        "python-redis-lock==3.6.0",
         "requests==2.21.0",
         "six==1.15.0",
         "Flask-Caching==1.8",


### PR DESCRIPTION
Redis lock was used to solve a specific logic in the Alto integrations, we can remove this from the base repo and take another approach in the integrations if required.