### PR TITLE
Chore/remove response to check

### DIFF
--- a/integration/rest_service/adapters.py
+++ b/integration/rest_service/adapters.py
@@ -1,5 +1,3 @@
-from typing import Dict, Union
-
 from flask import request
 
 from .data_classes import CheckData, Response
@@ -9,14 +7,6 @@ class BackgroundCheckClientAdapter:
     name = None
 
     def create_check(self, data: CheckData) -> Response:
-        raise NotImplementedError
-
-    def create_check_request(self, data: CheckData) -> Dict:
-        raise NotImplementedError
-
-    def response_to_check(
-        self, data: Dict[str, Union[str, int, Dict[str, int]]], input_data: CheckData
-    ) -> Response:
         raise NotImplementedError
 
     def get_check(self, data: CheckData) -> Response:


### PR DESCRIPTION
Remove `response_to_check` and `create_check_request` methods from adapters. This method is used only in the integration for checkr us, if we keep this method in the base class the integrators could think that is necessary to create a method to build the response. Since the integrators are free to build their services in the way they estimate better is not necessary to keep this method in the base class

Please check changes in integration/rest_service/adapters.py
