### PR TITLE
Chore/jsonify response

### DIFF
--- a/integration/app.py
+++ b/integration/app.py
@@ -107,7 +107,7 @@ def run_app(cls):
 
         try:
             response_data = background_check_adapter.create_check(data=check_data)
-            return response_data
+            return jsonify(response_data)
         except GenericAPIException as e:
             logger.info(
                 f"BGC request error {e.error_message}",
@@ -127,7 +127,7 @@ def run_app(cls):
 
         try:
             response_data = background_check_adapter.get_check(data=check_data)
-            return response_data
+            return jsonify(response_data)
         except GenericAPIException as e:
             logger.info(
                 f"BGC request error {e.error_message}",


### PR DESCRIPTION
We have differences between what we are requesting as a response in the adapters methods and what we are responding. According to our adapter the methods `create_check` and `get_check` respond with the data class `Response` but in the app.py method we are returning the serialized data, so the commented methods are responding with `jsonify(Response...)`. 

To ensure the datatypes in the app method we shouldn't allow a Dict as a response. In this version, the responsibility to serialize the data is on app.py and the adapters methods have to response with the `Response` dataclass

Before merging this change I will apply a tag to the current version and update the version on the production repo to use the same version. Once applied the change in the checkr repo I will update it to the latest library version

check lines
https://github.com/jeffersonlizar/bgc-integration/compare/chore/jsonify-response?expand=1#diff-e77642cce9f64d76b3c5addf9acdad0f9f7bdacb3f512f1098f8751ecdf169b1R110

https://github.com/jeffersonlizar/bgc-integration/compare/chore/jsonify-response?expand=1#diff-e77642cce9f64d76b3c5addf9acdad0f9f7bdacb3f512f1098f8751ecdf169b1R130