### PR TITLE
chore(app): use flask env for env var

### DIFF
--- a/integration/app.py
+++ b/integration/app.py
@@ -15,7 +15,7 @@ from integration.rest_service.providers.exceptions import GenericAPIException
 logger = logging.getLogger(__name__)
 
 
-ENVIRONMENT = getenv("FLASK_ENVIRONMENT", "local")
+ENVIRONMENT = getenv("FLASK_ENV", "local")
 SENTRY_DSN = getenv("SENTRY_DSN", None)
 
 if SENTRY_DSN:


### PR DESCRIPTION
use FLASK_ENV as env var since is the expected value in infra script and is the value used in the rest of tech expansion proyects